### PR TITLE
fix metadata.json creation on Linux caused by windows path

### DIFF
--- a/src/checkers/manager.py
+++ b/src/checkers/manager.py
@@ -100,7 +100,7 @@ def perform_checking(checks, shows, campaign_folder, stop_event, finish_event):
                 check_map[outvar] = (checker_class, output)
     try:
         checkers = [c() for c in list(set([check_map[check][0] for check in checks]))] # Instantiate a single object from each class
-        for folder in glob.glob(f".\\saves\\{campaign_folder}\\*\\"):
+        for folder in glob.glob(os.path.join("saves", campaign_folder, "*")):
             if stop_event.is_set():
                 raise InterruptedError("Stop event set")
             if is_reserved_folder(folder):


### PR DESCRIPTION
This PR fixes an issue where save folders were not correctly lopped on Linux and macOS due to Windows-specific backslash paths (\\).